### PR TITLE
Remover espaços e quebras de linhas do input do usuário

### DIFF
--- a/Modulos/YouDow.py
+++ b/Modulos/YouDow.py
@@ -9,6 +9,7 @@ while url != 5:
     Menu.menu()
     try:
         url = input("OPÇÃO: ")
+        url = url.strip()
         if url == "1":
             url1 = input("URL: ")
             Menu.baixa()


### PR DESCRIPTION
Durante a utilização do programa, é muito comum que o usuário se atrapalhe e acabe botando alguns espaços no início ou no fim do input na hora de escolher a opção.
No código atual do projeto, tal descuido faria com que o programa responda com um erro: "Opcao Invalida... Tente Novamente"
Para deixar tudo mais amigável ao usuário, podemos adicionar a função .strip() na hora de pegar a opção escolhida.
Essa função, (equivalente ao .trim() no JavaScript) retira os espaços e quebras de linhas na string escolhida.

Exemplo: 
`string = " 1      " ` # Definimos uma variável de nome string e valor `" 1      "`
`string.strip()`  # Ao aplicamos a função .strip() nessa variável, temos como retorno: `"1"`

Para mais informações e exemplos, visite [esse site](https://www.w3schools.com/python/ref_string_strip.asp)